### PR TITLE
The method setTrackerUrl is registered more than once in "_paq" variable

### DIFF
--- a/view/frontend/web/js/tracker.js
+++ b/view/frontend/web/js/tracker.js
@@ -288,7 +288,17 @@ define([
     }
 
     /**
-     * Initialzie this component with given options
+     * Checks that piwik.js is already on page
+     *
+     * @param {String} scriptUrl
+     * @returns {boolean}
+     */
+    function scriptExists(scriptUrl) {
+        return $('script[src="' + scriptUrl + '"]').length === 1;
+    }
+
+    /**
+     * Initialize this component with given options
      *
      * @param {Object} options
      */
@@ -296,11 +306,13 @@ define([
         defaultSiteId = options.siteId;
         defaultTrackerUrl = options.trackerUrl;
         if (piwik === null) {
-            pushAction([
-                ['setSiteId', defaultSiteId],
-                ['setTrackerUrl', defaultTrackerUrl]
-            ]);
-            injectScript(options.scriptUrl);
+            if (scriptExists(options.scriptUrl)) {
+                pushAction([
+                    ['setSiteId', defaultSiteId],
+                    ['setTrackerUrl', defaultTrackerUrl]
+                ]);
+                injectScript(options.scriptUrl);
+            }
         } else {
             // If we already have the Piwik object we can resolve any pending
             // promises immediately.


### PR DESCRIPTION
I've faced the same issue as It was described in https://github.com/henkelund/magento2-henhed-piwik/issues/15

### Preconditions
1. Magento 2.2.3
2. henhed/module-piwik 2.0.0
3. Google Chrome

### Steps to reproduce
1. open dev console
1. add some product to the Shopping Cart
2. go to the checkout page
3. see errors on the dev console

### Expected result
<!--- Tell us what should happen -->
1. there mustn't be any errors on the dev console

### Actual result
<!--- Tell us what happens instead -->
1. there are js errors:
![piwik-js-console-error](https://user-images.githubusercontent.com/6198012/37776520-23c1db2a-2dee-11e8-833f-6aa147ef5cc6.png)


<!--- (This may be platform independent comment) -->

------ 
if this issue you cannot reproduce, refresh your checkout page few times


It's happening because on the checkout page code 
https://github.com/henkelund/magento2-henhed-piwik/blob/master/view/frontend/templates/piwik.phtml#L36-L49 
runs in paralel with code 
https://github.com/henkelund/magento2-henhed-piwik/blob/master/view/frontend/web/js/tracker.js#L298-L303
 as result tracker.js tries to inject piwik.js file second time.
